### PR TITLE
Improve blackjack menu and add feedback flow

### DIFF
--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -284,6 +284,14 @@ def crypto_invoice_menu(invoice_id: str, lang: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 
+def confirm_cancel(invoice_id: str, lang: str) -> InlineKeyboardMarkup:
+    inline_keyboard = [
+        [InlineKeyboardButton('✅ Yes', callback_data=f'confirm_cancel_{invoice_id}')],
+        [InlineKeyboardButton('🔙 Back', callback_data=f'check_{invoice_id}')],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
 def crypto_choice() -> InlineKeyboardMarkup:
     inline_keyboard = [
         [InlineKeyboardButton('ETH', callback_data='crypto_ETH'),
@@ -324,3 +332,43 @@ def blackjack_controls() -> InlineKeyboardMarkup:
          InlineKeyboardButton('🛑 Stand', callback_data='blackjack_stand')]
     ]
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def blackjack_bet_menu(balance: float) -> InlineKeyboardMarkup:
+    inline_keyboard = []
+    max_bet = min(5, int(balance))
+    row = []
+    for i in range(1, max_bet + 1):
+        row.append(InlineKeyboardButton(f'{i}€', callback_data=f'blackjack_bet_{i}'))
+        if len(row) == 3:
+            inline_keyboard.append(row)
+            row = []
+    if row:
+        inline_keyboard.append(row)
+    inline_keyboard.append([InlineKeyboardButton('📜 History', callback_data='blackjack_history_0')])
+    inline_keyboard.append([InlineKeyboardButton('🔙 Back to menu', callback_data='back_to_menu')])
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def blackjack_end_menu(bet: int) -> InlineKeyboardMarkup:
+    inline_keyboard = [
+        [InlineKeyboardButton(f'▶️ Play Again ({bet}€)', callback_data=f'blackjack_play_{bet}')],
+        [InlineKeyboardButton('🔙 Back to menu', callback_data='blackjack')]
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def blackjack_history_menu(index: int, total: int) -> InlineKeyboardMarkup:
+    buttons = []
+    if index > 0:
+        buttons.append(InlineKeyboardButton('◀️', callback_data=f'blackjack_history_{index-1}'))
+    buttons.append(InlineKeyboardButton(f'{index+1}/{total}', callback_data='dummy_button'))
+    if index < total - 1:
+        buttons.append(InlineKeyboardButton('▶️', callback_data=f'blackjack_history_{index+1}'))
+    inline_keyboard = [buttons, [InlineKeyboardButton('🔙 Back', callback_data='blackjack')]]
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def feedback_menu(prefix: str) -> InlineKeyboardMarkup:
+    buttons = [InlineKeyboardButton(str(i), callback_data=f'{prefix}_{i}') for i in range(1, 6)]
+    return InlineKeyboardMarkup(inline_keyboard=[buttons])

--- a/bot/localization.py
+++ b/bot/localization.py
@@ -29,6 +29,9 @@ LANGUAGES = {
         'invoice_cancelled': 'Payment failed/expired. Your items are no longer reserved.',
         'total_purchases': '📦 Total Purchases: {count}',
         'note': '⚠️ Note: No refunds. Please ensure you send the exact amount for payments, as underpayments will not be confirmed.',
+        'feedback_service': 'How was your experience with the service?',
+        'feedback_product': 'Opinion on the product?',
+        'thanks_feedback': 'Thanks for your feedback!',
 
         'choose_subcategory': '🏘️ Choose a district:',
         'select_product': '🏪 Select a product',
@@ -69,6 +72,9 @@ LANGUAGES = {
         'invoice_cancelled': 'Оплата не завершена/истекла. Ваши товары больше не зарезервированы.',
         'total_purchases': '📦 Всего покупок: {count}',
         'note': '⚠️ Возврат средств невозможен. Отправляйте точную сумму, недоплаты не подтверждаются.',
+        'feedback_service': 'Как вам обслуживание?',
+        'feedback_product': 'Мнение о товаре?',
+        'thanks_feedback': 'Спасибо за отзыв!',
 
         'choose_subcategory': '🏘️ Выберите район:',
         'select_product': '🏪 Выберите товар',
@@ -108,6 +114,9 @@ LANGUAGES = {
         'invoice_cancelled': 'Mokėjimas nepavyko/baigėsi. Jūsų prekės nebėra rezervuotos.',
         'total_purchases': '📦 Viso pirkinių: {count}',
         'note': '⚠️ Pastaba: grąžinimų nėra. Įsitikinkite, kad siunčiate tikslią sumą, nes nepakankamos sumos nebus patvirtintos.',
+        'feedback_service': 'Kaip vertinate aptarnavimą?',
+        'feedback_product': 'Kokia nuomonė apie prekę?',
+        'thanks_feedback': 'Ačiū už atsiliepimą!',
 
         'choose_subcategory': '🏘️ Pasirinkite rajoną:',
         'select_product': '🏪 Pasirinkite prekę',

--- a/bot/misc/config.py
+++ b/bot/misc/config.py
@@ -5,6 +5,7 @@ from typing import Final
 class TgConfig(ABC):
     STATE: Final = {}
     BASKETS: Final = {}
+    BLACKJACK_STATS: Final = {}
     CHANNEL_URL: Final = 'https://t.me/NBAXSHOP'
     HELPER_URL: Final = '@SugarFromShef'
     REVIEWS_URL: Final = 'https://t.me/+-yPLEiJwp-IxYzlk'
@@ -13,3 +14,4 @@ class TgConfig(ABC):
     REFERRAL_PERCENT = 5
     PAYMENT_TIME: Final = 1800
     RULES: Final = 'insert your rules here'
+    START_PHOTO_PATH: Final = 'assets/start.jpg'


### PR DESCRIPTION
## Summary
- Show welcome image on /start and enhance blackjack with bet menu, history, and PNL stats
- Ask for purchase feedback and notify admin on purchases, top-ups, and blackjack results
- Confirm payment cancellation and simplify purchased item details

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a23977d9d88332a1af78ef6a58e09d